### PR TITLE
Update the README but not the CHANGELOG

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,31 +1,22 @@
+
 <!--
 Thank you for contributing to capa! <3
-
-IMPORTANT NOTE
-It's most important that you submit your improvements. So even if you don't use this complete template we look forward to collaborating!
 
 Please read capa's CONTRIBUTING guide if you haven't done so already.
 It contains helpful information about how to contribute to capa. Check https://github.com/fireeye/capa/blob/master/.github/CONTRIBUTING.md
 
-PR template based on https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/
+Please describe the changes in this pull request (PR). Include your motivation and context to help us review.
+
+Please mention the issue your PR addresses (if any):
+closes #issue_number
 -->
 
-### Description
 
-<!-- Please describe the changes in this PR. Include your motivation and context to help us review. -->
+### Checklist
 
-closes # (issue)
-
-### Documentation
-
-- [ ] I have updated the [CHANGELOG.md](/CHANGELOG.md), this is required for:
-  - Bug fixes (non-breaking change which fixes an issue)
-  - New features (non-breaking change which adds functionality)
-  - Breaking changes (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
-  - [ ] I have made the corresponding changes to the documentation
-
-### Tests
-
-- [ ] I have added tests that prove my fix is effective or that my feature works
+<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think it is worthwhile mentioning in the release notes to this file. -->
+- [ ] No CHANGELOG update needed
+<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
 - [ ] No new tests needed
+<!-- Please help us keeping capa documentation up-to-date -->
+- [ ] No documentation update needed

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,39 @@
+name: changelog
+
+on:
+  # We need pull_request_target instead of pull_request because a write
+  # repository token is needed to add a review to a PR. DO NOT BUILD
+  # OR RUN UNTRUSTED CODE FROM PRs IN THIS ACTION
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check_changelog:
+    runs-on: ubuntu-20.04
+    env:
+      NO_CHANGELOG: '[X] No CHANGELOG update needed'
+    steps:
+    - name: Get changed files
+      id: files
+      uses: jitterbit/get-changed-files@v1
+    - name: check changelog updated
+      id: changelog_updated
+      env:
+        PR_BODY: ${{ github.event.pull_request.body }}
+        FILES: ${{ steps.files.outputs.modified }}
+      run: |
+        echo $FILES | grep -qF 'CHANGELOG.md' || echo $PR_BODY | grep -qF "$NO_CHANGELOG"
+    - name: Reject pull request if no CHANGELOG update
+      if: ${{ always() && steps.changelog_updated.outcome == 'failure' }}
+      uses: andrewmusgrave/automatic-pull-request-review@0.0.5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        event: REQUEST_CHANGES
+        body: "Please add bug fixes, new features, breaking changes and anything else you think it is worthwhile mentioning to the `master (unreleased)` section of CHANGELOG.md. If no CHANGELOG update is needed add the following to the PR description: `${{ env.NO_CHANGELOG }}`"
+    - name: Dismiss previous review if CHANGELOG update
+      uses: andrewmusgrave/automatic-pull-request-review@0.0.5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        event: DISMISS
+        body: "Changes addressed, thanks!"
+

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,15 +25,17 @@ jobs:
         echo $FILES | grep -qF 'CHANGELOG.md' || echo $PR_BODY | grep -qF "$NO_CHANGELOG"
     - name: Reject pull request if no CHANGELOG update
       if: ${{ always() && steps.changelog_updated.outcome == 'failure' }}
-      uses: andrewmusgrave/automatic-pull-request-review@0.0.5
+      uses: Ana06/automatic-pull-request-review@allow_duplicates
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         event: REQUEST_CHANGES
         body: "Please add bug fixes, new features, breaking changes and anything else you think it is worthwhile mentioning to the `master (unreleased)` section of CHANGELOG.md. If no CHANGELOG update is needed add the following to the PR description: `${{ env.NO_CHANGELOG }}`"
+        allow_duplicate: false
     - name: Dismiss previous review if CHANGELOG update
-      uses: andrewmusgrave/automatic-pull-request-review@0.0.5
+      uses: Ana06/automatic-pull-request-review@allow_duplicates
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         event: DISMISS
         body: "Changes addressed, thanks!"
+        allow_duplicate: false
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - name: Get changed files
       id: files
-      uses: jitterbit/get-changed-files@v1
+      uses: Ana06/get-changed-files@master
     - name: check changelog updated
       id: changelog_updated
       env:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Downloads](https://img.shields.io/github/downloads/fireeye/capa/total)](https://github.com/fireeye/capa/releases)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE.txt)
 
-I am adding some important information.
+I am adding some important information again!
 capa detects capabilities in executable files.
 You run it against a PE file or shellcode and it tells you what it thinks the program can do.
 For example, it might suggest that the file is a backdoor, is capable of installing services, or relies on HTTP to communicate.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Downloads](https://img.shields.io/github/downloads/fireeye/capa/total)](https://github.com/fireeye/capa/releases)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE.txt)
 
+I am adding some important information.
 capa detects capabilities in executable files.
 You run it against a PE file or shellcode and it tells you what it thinks the program can do.
 For example, it might suggest that the file is a backdoor, is capable of installing services, or relies on HTTP to communicate.


### PR DESCRIPTION
I have updated the README but I "forgot" the CHANGELOG. 😈
<!--
Thank you for contributing to capa! <3

Please read capa's CONTRIBUTING guide if you haven't done so already.
It contains helpful information about how to contribute to capa. Check https://github.com/fireeye/capa/blob/master/.github/CONTRIBUTING.md

Please describe the changes in this pull request (PR). Include your motivation and context to help us review.

Please mention the issue your PR addresses (if any):
closes #issue_number
-->


### Checklist

<!-- CHANGELOG.md has a `master (unreleased)` section. Please add bug fixes, new features, breaking changes and anything else you think it is worthwhile mentioning in the release notes to this file. -->
- [ ] No CHANGELOG update needed
<!-- Tests prove that your fix/work as expected and ensure it doesn't break on the feature. -->
- [ ] No new tests needed
<!-- Please help us keeping capa documentation up-to-date -->
- [x] No documentation update needed
